### PR TITLE
Clean up the APT cache for best practice

### DIFF
--- a/Dockerfile-apollo
+++ b/Dockerfile-apollo
@@ -24,7 +24,8 @@ RUN cd ${CATALINA_BASE}/webapps/ROOT/jbrowse/plugins && \
      bash setup.sh
 
 # groovy needed for scripts
-RUN apt-get update && apt-get -y install groovy
+RUN apt-get update && apt-get -y install groovy \
+    && rm -rf /var/lib/apt/lists/*
 
 # BLAT and faToTwoBit needed for BLAT searches
 RUN curl -s "http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/blat/blat" -o /usr/local/bin/blat && \

--- a/Dockerfile-httpd
+++ b/Dockerfile-httpd
@@ -7,11 +7,11 @@ ENV      DEBIAN_FRONTEND noninteractive
 
 RUN   apt-get -qq update --fix-missing && \
       apt-get install --yes apt-utils && \
-      apt-get install --no-install-recommends -y ca-certificates curl less links procps ssl-cert tcpdump vim zip
-
-# install OIDC module and assert its presence in expected location
-RUN   apt-get install --yes --fix-missing libapache2-mod-auth-openidc && \
-      ls -l /usr/lib/apache2/modules/mod_auth_openidc.so
+      apt-get install --no-install-recommends -y ca-certificates curl less links procps ssl-cert tcpdump vim zip && \
+      # install OIDC module and assert its presence in expected location
+      apt-get install --yes --fix-missing libapache2-mod-auth-openidc && \
+      ls -l /usr/lib/apache2/modules/mod_auth_openidc.so \
+      && rm -rf /var/lib/apt/lists/*
 
 # keep stock httpd.conf, just add conf.d directive
 RUN echo "Include conf.d/*.conf" >> /usr/local/apache2/conf/httpd.conf


### PR DESCRIPTION
Removed APT cache after installing groovy for a slimmer image layer on Dockerfile-httpd.

I also collapsed APT installs on Dockerfile-httpd. If libapache2-mod-auth-openidc really needs its own layer, it should include its own apt-get update and rm on the APT cache and not rely on a previous layer’s APT cache.