### PR TITLE
J browse update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "JBrowse"]
 	path = JBrowse
 	url = https://github.com/VEuPathDB/JBrowse.git
-	branch = api-build-51
+	branch = api-build-66


### PR DESCRIPTION
Updating JBrowse submodule to get latest plugins for use in Apollo.

Specified in .gitmodules that the JBrowse submodule should use api-build-66 branch, and then update submodule.

@pwilx666 Suggest that you:

1. Pull my branch, and build it locally to check it works (I did this already, but a second test is always good)
2. If you're happy, merge it to master 
3. Tag it again, and check the image builds in Jenkins
4. Request your updates to our dev instance, followed by sandbox and prod if you're happy